### PR TITLE
Use https rather than http for restoring packages from Jfrog.

### DIFF
--- a/train-timetables/pom.xml
+++ b/train-timetables/pom.xml
@@ -24,7 +24,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -34,7 +34,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray-plugins</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Jfrog has removed support for http so the packages will not resolve. mvn verify command will fail upon initial install.

See http://jcenter.bintray.com or https://jfrog.com/jcenter-http/